### PR TITLE
missing fixtures / superfluous test app

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include setup.py README.rst MANIFEST.in LICENSE
 recursive-include organizations/templates *
+recursive-include organizations/fixtures *

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     ],
     #test_suite='tests.runtests.runtests',
     include_package_data=True,
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests.tests", "tests.test_app", "tests"]),
     zip_safe=False
 )


### PR DESCRIPTION
Hi Ben,

the package you are distributing at the moment is a bit too big and a bit too small at the same time. It is missing your fixtures that are required to execute your tests and it contains your test application which not required there. 

I excluded your test app and added the fixtures.

Could you please have a look and pull my changes?

Best Regards,
Sebastian
