### PR TITLE
Parameter 'organization_pk' required.

### DIFF
--- a/organizations/views.py
+++ b/organizations/views.py
@@ -121,7 +121,8 @@ class BaseOrganizationUserUpdate(OrganizationUserMixin, UpdateView):
 
 class BaseOrganizationUserDelete(OrganizationUserMixin, DeleteView):
     def get_success_url(self):
-        return reverse("organizationuser_list")
+        return reverse('organization_user_list',
+                kwargs={'organization_pk': self.object.organization.pk})
 
 
 class OrganizationSignup(FormView):


### PR DESCRIPTION
The parameter 'organization_pk' is required in order to be able
to reverse named url 'organization_user_list'
