### PR TITLE
Increase emailfield length to 75 for OrganizationAddForm

### DIFF
--- a/organizations/forms.py
+++ b/organizations/forms.py
@@ -95,7 +95,7 @@ class OrganizationAddForm(forms.ModelForm):
     Form class for creating a new organization, complete with new owner, including a
     User instance, OrganizationUser instance, and OrganizationOwner instance.
     """
-    email = forms.EmailField(max_length=30,
+    email = forms.EmailField(max_length=75,
             help_text=_("The email address for the account owner"))
 
     def __init__(self, request, *args, **kwargs):


### PR DESCRIPTION
A very small change! Hope I've done the right thing here, I'm new to git and contributing to projects. The 30 character length could cause problems if users don't notice their address has been truncated. 75 is the same as the new user email field.
