### PR TITLE
Fixing CONTRIBUTING docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -36,8 +36,8 @@ is open to whoever wants to implement it.
 Write Documentation
 ~~~~~~~~~~~~~~~~~~~
 
-Py-Geocod.io could always use more documentation, whether as part of the 
-official Py-Geocod.io docs, in docstrings, or even on the web in blog posts,
+Django-organizations could always use more documentation, whether as part of the 
+official Django-organizations docs, in docstrings, or even on the web in blog posts,
 articles, and such.
 
 Submit Feedback
@@ -66,7 +66,7 @@ Ready to contribute? Here's how to set up `django-organizations` for local devel
 
     $ mkvirtualenv django-organizations
     $ cd django-organizations/
-    $ python setup.py develop
+    $ pip install -r requirements_dev.txt
 
 4. Create a branch for local development::
 
@@ -76,11 +76,9 @@ Ready to contribute? Here's how to set up `django-organizations` for local devel
 
 5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
 
-    $ flake8 organizations tests
-    $ python setup.py test
-    $ tox
-
-   To get flake8 and tox, just pip install them into your virtualenv. 
+    $ flake8 organizations
+    $ python runtests.py
+    $ tox 
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-coverage
-mock>=1.0.1
-nose>=1.3.0
-django-nose>=1.2
-wheel

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,6 @@
+Django>=1.4.2,<1.8
+django-extensions>=0.9
+django-nose==1.2
+flake8==2.1.0
+tox==1.7.1
+mock>=1.0.1

--- a/runtests.py
+++ b/runtests.py
@@ -39,7 +39,7 @@ try:
 
     from django_nose import NoseTestSuiteRunner
 except ImportError:
-    raise ImportError("To fix this error, run: pip install -r requirements-test.txt")
+    raise ImportError("To fix this error, run: pip install -r requirements_dev.txt")
 
 
 def run_tests(*test_args):

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         'Django>=1.4.2,<1.8',
         'django-extensions>=0.9',
     ],
-    test_suite='tests',
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
This PR does not just fix the docs (contributing part) but also fixes (I
guess so) some tips about how to create the environment to develop new
features/fix bugs. To accomplish it I changed some that were raising
errors like 'python setup.py test' (nosetests does not run this way).
updated setup.py and requirements.txt was replaced by
requirements_dev.txt.
I also took advantage to fix a type where another
project was referenced instead of Django-organizations.
