### PR TITLE
Allow configurable TimeStampModel

### DIFF
--- a/organizations/models.py
+++ b/organizations/models.py
@@ -2,14 +2,23 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models import permalink, get_model
+from django.utils.importlib import import_module
 from django.utils.translation import ugettext_lazy as _
 
 from django_extensions.db.fields import AutoSlugField
-from django_extensions.db.models import TimeStampedModel
 
 from .base import OrganizationBase, OrganizationUserBase, OrganizationOwnerBase
 
 USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+ORGS_TIMESTAMPED_MODEL = getattr(settings, 'ORGS_TIMESTAMPED_MODEL')
+
+
+try:
+    module, klass = ORGS_TIMESTAMPED_MODEL.rsplit('.', 1)
+    TimeStampedModel = getattr(import_module(module), klass)
+except:
+    raise ImproperlyConfigured("Your TimeStampedBaseModel class, {0},"
+            " is improperly defined".format(ORGS_TIMESTAMPED_MODEL))
 
 
 def get_user_model():

--- a/runtests.py
+++ b/runtests.py
@@ -32,7 +32,8 @@ try:
         ],
         SITE_ID=1,
         NOSE_ARGS=['-s'],
-        FIXTURE_DIRS=['tests/fixtures']
+        FIXTURE_DIRS=['tests/fixtures'],
+        ORGS_TIMESTAMPED_MODEL='django_extensions.db.models.TimeStampedModel',
     )
     if hasattr(django, 'setup'):
         django.setup()


### PR DESCRIPTION
This commit adds the possibility to set a TimeStamped model via
settings.
ORGS_TIMESTAMPED_MODEL is required to run otherwise it will raise a
ImproperlyConfigured exception.
