### PR TITLE
Fix to add user as sender to invite_by_email method.

### DIFF
--- a/organizations/forms.py
+++ b/organizations/forms.py
@@ -78,7 +78,8 @@ class OrganizationUserAddForm(forms.ModelForm):
             user = invitation_backend().invite_by_email(
                     self.cleaned_data['email'],
                     **{'domain': get_current_site(self.request),
-                        'organization': self.organization})
+                        'organization': self.organization,
+                        'sender': self.request.user})
         return OrganizationUser.objects.create(user=user,
                 organization=self.organization,
                 is_admin=self.cleaned_data['is_admin'])

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -2,7 +2,8 @@ from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
-from organizations.forms import OrganizationForm, OrganizationUserForm
+from organizations.forms import (OrganizationForm, OrganizationUserForm,
+        OrganizationUserAddForm)
 from organizations.models import Organization
 from .utils import request_factory_login
 
@@ -63,5 +64,13 @@ class OrgFormTests(TestCase):
     def test_save_user_form(self):
         form = OrganizationUserForm(instance=self.owner,
                 data={'is_admin': True})
+        self.assertTrue(form.is_valid())
+        form.save()
+
+    def test_save_org_user_add_form(self):
+        request = request_factory_login(self.factory, self.owner.user)
+        form = OrganizationUserAddForm(request=request, organization=self.org, data={
+                'email': 'test_email@example.com',
+                'is_admin': False})
         self.assertTrue(form.is_valid())
         form.save()


### PR DESCRIPTION
The OrganizationUserAddForm does not pass in the `request.user` as the
sender to the `invite_by_email` method. Therefore, the sender argument
resolves to `None`. An empty sender, in turn, creates an incomplete
invitation email body and defaults the `reply_to` to the
DEFAULT_FROM_EMAIL setting.
