### PR TITLE
Filters to determine user role in an organization.

### DIFF
--- a/organizations/templatetags/org_tags.py
+++ b/organizations/templatetags/org_tags.py
@@ -7,3 +7,13 @@ register = template.Library()
 def organization_users(context, org):
     context.update({'organization_users': org.organization_users.all()})
     return context
+
+
+@register.filter
+def is_admin(org, user):
+    return org.is_admin(user)
+
+
+@register.filter
+def is_owner(org, user):
+    return org.owner.organization_user.user == user

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,0 +1,52 @@
+from django.test import TestCase
+from django.template import Template, Context
+from django.contrib.auth.models import User
+from django.test.utils import override_settings
+
+from organizations.models import Organization
+
+
+@override_settings(USE_TZ=True)
+class OrgFilterTests(TestCase):
+
+    fixtures = ['users.json', 'orgs.json']
+
+    def setUp(self):
+        self.kurt = User.objects.get(username="kurt")
+        self.dave = User.objects.get(username="dave")
+        self.nirvana = Organization.objects.get(name="Nirvana")
+        self.foo = Organization.objects.get(name="Foo Fighters")
+        self.context = {}
+
+    def test_is_owner_org_filter(self):
+        self.context = {'organization': self.nirvana,
+                        'user': self.kurt}
+        out = Template(
+            "{% load org_tags %}"
+            "{% if organization|is_owner:user %}"
+            "Is Owner"
+            "{% endif %}"
+        ).render(Context(self.context))
+        self.assertEqual(out, "Is Owner")
+
+    def test_is_admin_org_filter(self):
+        self.context = {'organization': self.foo,
+                        'user': self.dave}
+        out = Template(
+            "{% load org_tags %}"
+            "{% if organization|is_admin:user %}"
+            "Is Admin"
+            "{% endif %}"
+        ).render(Context(self.context))
+        self.assertEqual(out, "Is Admin")
+
+    def test_is_not_admin_org_filter(self):
+        self.context = {'organization': self.nirvana,
+                        'user': self.dave}
+        out = Template(
+            "{% load org_tags %}"
+            "{% if not organization|is_admin:user %}"
+            "Is Not Admin"
+            "{% endif %}"
+        ).render(Context(self.context))
+        self.assertEqual(out, "Is Not Admin")


### PR DESCRIPTION
This feature allows for the ability to utilize template conditionals to
customize user functionality and/or behavior depending on their role
with a given organization.

The two main roles that a user can have with an organization are if the
user is an organization owner or an organization admin.
