### PR TITLE
Custom signals for organization changes.

### DIFF
--- a/organizations/forms.py
+++ b/organizations/forms.py
@@ -24,8 +24,7 @@ class OrganizationForm(forms.ModelForm):
 
     def save(self, commit=True):
         if self.instance.owner.organization_user != self.cleaned_data['owner']:
-            self.instance.owner.organization_user = self.cleaned_data['owner']
-            self.instance.owner.save()
+            self.instance.change_owner(self.cleaned_data['owner'])
         return super(OrganizationForm, self).save(commit=commit)
 
     def clean_owner(self):

--- a/organizations/signals.py
+++ b/organizations/signals.py
@@ -1,0 +1,8 @@
+import django.dispatch
+
+user_kwargs = {"providing_args": ["user"]}
+user_added = django.dispatch.Signal(**user_kwargs)
+user_removed = django.dispatch.Signal(**user_kwargs)
+
+owner_kwargs = {"providing_args": ["old", "new"]}
+owner_changed = django.dispatch.Signal(**owner_kwargs)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,3 +6,6 @@ django-nose>=1.2
 
 # Required to test default models
 django-extensions>=0.9
+
+# Required for mocking signals
+mock-django>=0.6.5

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -96,6 +96,12 @@ class OrgModelTests(TestCase):
         owner = self.nirvana.owner.organization_user
         self.assertRaises(OwnershipRequired, owner.delete)
 
+    def test_change_owner(self):
+        admin = self.nirvana.organization_users.get(user__username="krist")
+        self.nirvana.change_owner(admin)
+        owner = self.nirvana.owner.organization_user
+        self.assertEqual(owner, admin)
+
     def test_delete_missing_owner(self):
         """Ensure an org user can be deleted when there is no owner"""
         org = Organization.objects.create(name="Some test", slug="some-test")

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,69 @@
+from mock import call
+from mock_django.signals import mock_signal_receiver
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from organizations.models import Organization
+from organizations.signals import (user_added, user_removed,
+                                   owner_changed)
+
+
+@override_settings(USE_TZ=True)
+class SignalsTestCase(TestCase):
+
+    fixtures = ['users.json', 'orgs.json']
+
+    def setUp(self):
+        self.kurt = User.objects.get(username="kurt")
+        self.dave = User.objects.get(username="dave")
+        self.krist = User.objects.get(username="krist")
+        self.duder = User.objects.get(username="duder")
+        self.foo = Organization.objects.get(name="Foo Fighters")
+        self.org = Organization.objects.get(name="Nirvana")
+        self.admin = self.org.organization_users.get(user__username="krist")
+        self.owner = self.org.organization_users.get(user__username="kurt")
+
+    def test_user_added_called(self):
+
+        with mock_signal_receiver(user_added) as add_receiver:
+            self.foo.add_user(self.krist)
+
+            self.assertEqual(add_receiver.call_args_list, [
+                call(signal=user_added, sender=self.foo, user=self.krist),
+            ])
+
+        with mock_signal_receiver(user_added) as add_receiver:
+            self.foo.get_or_add_user(self.duder)
+
+            self.assertEqual(add_receiver.call_args_list, [
+                call(signal=user_added, sender=self.foo, user=self.duder),
+            ])
+
+    def test_user_added_not_called(self):
+
+        with mock_signal_receiver(user_added) as add_receiver:
+            self.foo.get_or_add_user(self.dave)
+
+            self.assertEqual(add_receiver.call_args_list, [])
+
+    def test_user_removed_called(self):
+
+        with mock_signal_receiver(user_removed) as remove_receiver:
+            self.foo.add_user(self.krist)
+            self.foo.remove_user(self.krist)
+
+            self.assertEqual(remove_receiver.call_args_list, [
+                call(signal=user_removed, sender=self.foo, user=self.krist),
+            ])
+
+    def test_owner_changed_called(self):
+
+        with mock_signal_receiver(owner_changed) as changed_receiver:
+            self.org.change_owner(self.admin)
+
+            self.assertEqual(changed_receiver.call_args_list, [
+                call(signal=owner_changed, sender=self.org,
+                     old=self.owner, new=self.admin),
+            ])


### PR DESCRIPTION
Three signals are being added:
1. When a user is removed from an organization.
2. When a user is added to an organization.
3. When an organization changes ownership.

All three signals use the organization model as the sender. To better
capture change of ownership. The organization method `change_owner` was
created.

The philosophy behind this addition is to move responsibility of
changing ownership to the Organization model class versus the
OrganizationForm class.
