### PR TITLE
Minor Organization create view template fix

### DIFF
--- a/organizations/templates/organizations/organization_form.html
+++ b/organizations/templates/organizations/organization_form.html
@@ -1,6 +1,6 @@
 {% extends "organizations_base.html" %}
 {% block content %}
-<h1>{{ organization }}</h1>
+<h1>Create Organization</h1>
 <form action="." method="post">{% csrf_token %}
     {{ form }}
     <input type="submit" value="submit">

--- a/organizations/templates/organizations/organization_form.html
+++ b/organizations/templates/organizations/organization_form.html
@@ -1,6 +1,11 @@
 {% extends "organizations_base.html" %}
 {% block content %}
-<h1>Create Organization</h1>
+
+{% if organization %}
+  <h1>{{ organization }}</h1>
+{% else %}
+  <h1>Create Organization</h1>
+{% endif %}
 <form action="." method="post">{% csrf_token %}
     {{ form }}
     <input type="submit" value="submit">


### PR DESCRIPTION
`organization` is not part of the context of Organization's create view, so when using the default templates you end up with a blank heading when visiting that view. I simply changed the heading to read "Create Organization".