### PR TITLE
Fix: User is not set admin when creating a new organization

### DIFF
--- a/organizations/utils.py
+++ b/organizations/utils.py
@@ -69,7 +69,7 @@ def create_organization(user, name, slug=None, is_active=None,
     org_defaults.update({'name': name})
     organization = org_model.objects.create(**org_defaults)
 
-    org_user_defaults.update({'organization': organization, 'user': user})
+    org_user_defaults.update({'organization': organization, 'user': user, 'is_admin': True})
     new_user = org_user_model.objects.create(**org_user_defaults)
 
     org_owner_model.objects.create(organization=organization,


### PR DESCRIPTION
The user is not set as the admin of the organization when he is creating a new one. So, he cannot add the new users and edit the details of the organization. Setting 'is_admin' as True solves the problem. 

Cheers