### PR TITLE
Change Http404 to an appropriate HttpResponseForbidden

### DIFF
--- a/organizations/backends/defaults.py
+++ b/organizations/backends/defaults.py
@@ -33,7 +33,7 @@ from django.conf.urls import patterns, url
 from django.contrib.auth import authenticate, login
 from django.core.urlresolvers import reverse
 from django.core.mail import EmailMessage
-from django.http import Http404
+from django.http import HttpResponseForbidden
 from django.shortcuts import render, redirect
 from django.template import Context, loader
 from django.utils.translation import ugettext as _
@@ -107,9 +107,9 @@ class BaseBackend(object):
         try:
             user = self.user_model.objects.get(id=user_id, is_active=False)
         except self.user_model.DoesNotExist:
-            raise Http404(_("Your URL may have expired."))
+            return HttpResponseForbidden(_("Your URL may have expired."))
         if not RegistrationTokenGenerator().check_token(user, token):
-            raise Http404(_("Your URL may have expired."))
+            return HttpResponseForbidden(_("Your URL may have expired."))
         form = self.get_form(data=request.POST or None, instance=user)
         if form.is_valid():
             form.instance.is_active = True

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,7 +1,7 @@
 from django.core import mail
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
-from django.http import Http404, QueryDict
+from django.http import HttpResponseForbidden, QueryDict
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
@@ -68,9 +68,9 @@ class InvitationTests(TestCase):
 
     def test_activate_user(self):
         request = self.factory.request()
-        with self.assertRaises(Http404):
-            InvitationBackend().activate_view(request, self.user.id,
-                    self.tokenizer.make_token(self.user))
+        self.assertEqual(403, InvitationBackend().activate_view(request,
+            self.user.id,
+            self.tokenizer.make_token(self.user)).status_code)
         self.assertEqual(200, InvitationBackend().activate_view(request,
             self.pending_user.id,
             self.tokenizer.make_token(self.pending_user)).status_code)
@@ -134,9 +134,9 @@ class RegistrationTests(TestCase):
 
     def test_activate_user(self):
         request = self.factory.request()
-        with self.assertRaises(Http404):
-            RegistrationBackend().activate_view(request, self.user.id,
-                    self.tokenizer.make_token(self.user))
+        self.assertEqual(403, RegistrationBackend().activate_view(request,
+            self.user.id,
+            self.tokenizer.make_token(self.user)).status_code)
         self.assertEqual(200, RegistrationBackend().activate_view(request,
             self.pending_user.id,
             self.tokenizer.make_token(self.pending_user)).status_code)


### PR DESCRIPTION
Reference: https://en.wikipedia.org/wiki/HTTP_403
When a non existent user is being tried to activate, we don't need to explicitly respond telling that user does not exist(404) , but instead respond with 403.  