### PR TITLE
Support the "name <email@domain.tld>" form for DEFAULT_FROM_EMAIL

### DIFF
--- a/organizations/backends/defaults.py
+++ b/organizations/backends/defaults.py
@@ -26,6 +26,7 @@
 """Backend classes should provide common interface
 """
 
+import email.utils
 import uuid
 
 from django.conf import settings
@@ -140,7 +141,7 @@ class BaseBackend(object):
         """Utility method for sending emails to new users"""
         if sender:
             from_email = "%s %s <%s>" % (sender.first_name, sender.last_name,
-                    settings.DEFAULT_FROM_EMAIL)
+                    email.utils.parseaddr(settings.DEFAULT_FROM_EMAIL)[1])
             reply_to = "%s %s <%s>" % (sender.first_name, sender.last_name,
                     sender.email)
         else:


### PR DESCRIPTION
Currently, when `settings.DEFAULT_FROM_EMAIL` is not just an email address (e.g. `john.doe@example.com`), but the "pretty" version (e.g. `John Doe (Example Corp) <john.doe@example.com>`), `BaseBackend._send_email()` will yield an invalid `From` header when specifying a sender (when inviting users for example), in the form `Jane Roe <John Doe (Example Corp) <john.doe@example.com>>`.

This commit fixes the issue by using Python's own `email.utils.parseaddr` [1] to extract the exact email address.

[1] https://docs.python.org/3/library/email.util.html