### PR TITLE
Switch from HttpResponseForbidden to PermissionDenied

### DIFF
--- a/docs/custom_usage.rst
+++ b/docs/custom_usage.rst
@@ -82,7 +82,7 @@ on your project::
             self.service_provider = self.organization.provider
             if not self.organization.is_admin(request.user) and not \
                     self.service_provider.is_member(request.user):
-                return HttpResponseForbidden(_("Sorry, admins only"))
+                raise PermissionDenied(_("Sorry, admins only"))
             return super(AdminRequiredMixin, self).dispatch(request, *args,
                     **kwargs)
 
@@ -118,7 +118,7 @@ verbosity::
             self.service_provider = self.organization.provider
             if not self.organization.is_admin(request.user) and not \
                     self.service_provider.is_member(request.user):
-                return HttpResponseForbidden(_("Sorry, admins only"))
+                raise PermissionDenied(_("Sorry, admins only"))
             return super(AdminRequiredMixin, self).dispatch(request, *args,
                     **kwargs)
 

--- a/organizations/mixins.py
+++ b/organizations/mixins.py
@@ -22,8 +22,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-from django.http import HttpResponseForbidden
+from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 
@@ -91,7 +90,7 @@ class MembershipRequiredMixin(object):
         self.organization = self.get_organization()
         if not self.organization.is_member(request.user) and not \
                 request.user.is_superuser:
-            return HttpResponseForbidden(_("Wrong organization"))
+            raise PermissionDenied(_("Wrong organization"))
         return super(MembershipRequiredMixin, self).dispatch(request, *args,
                 **kwargs)
 
@@ -106,7 +105,7 @@ class AdminRequiredMixin(object):
         self.organization = self.get_organization()
         if not self.organization.is_admin(request.user) and not \
                 request.user.is_superuser:
-            return HttpResponseForbidden(_("Sorry, admins only"))
+            raise PermissionDenied(_("Sorry, admins only"))
         return super(AdminRequiredMixin, self).dispatch(request, *args,
                 **kwargs)
 
@@ -121,6 +120,6 @@ class OwnerRequiredMixin(object):
         self.organization = self.get_organization()
         if self.organization.owner.organization_user.user != request.user \
                 and not request.user.is_superuser:
-            return HttpResponseForbidden(_("You are not the organization owner"))
+            raise PermissionDenied(_("You are not the organization owner"))
         return super(OwnerRequiredMixin, self).dispatch(request, *args,
                 **kwargs)

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import User
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -85,8 +86,9 @@ class AccessMixinTests(TestCase):
             organization_pk=self.nirvana.pk).status_code)
         self.assertEqual(200, MemberView().dispatch(self.dave_request,
             organization_pk=self.nirvana.pk).status_code)
-        self.assertEqual(403, MemberView().dispatch(self.dummy_request,
-            organization_pk=self.nirvana.pk).status_code)
+        with self.assertRaises(PermissionDenied):
+            MemberView().dispatch(self.dummy_request,
+                                  organization_pk=self.nirvana.pk)
 
     def test_admin_access(self):
         class AdminView(AdminRequiredMixin, OrgView):
@@ -98,18 +100,21 @@ class AccessMixinTests(TestCase):
         # Superuser
         self.assertEqual(200, AdminView().dispatch(self.dave_request,
             organization_pk=self.nirvana.pk).status_code)
-        self.assertEqual(403, AdminView().dispatch(self.dummy_request,
-            organization_pk=self.nirvana.pk).status_code)
+        with self.assertRaises(PermissionDenied):
+            AdminView().dispatch(self.dummy_request,
+                                 organization_pk=self.nirvana.pk)
 
     def test_owner_access(self):
         class OwnerView(OwnerRequiredMixin, OrgView):
             pass
         self.assertEqual(200, OwnerView().dispatch(self.kurt_request,
             organization_pk=self.nirvana.pk).status_code)
-        self.assertEqual(403, OwnerView().dispatch(self.krist_request,
-            organization_pk=self.nirvana.pk).status_code)
+        with self.assertRaises(PermissionDenied):
+            OwnerView().dispatch(self.krist_request,
+                                 organization_pk=self.nirvana.pk)
         # Superuser
         self.assertEqual(200, OwnerView().dispatch(self.dave_request,
             organization_pk=self.nirvana.pk).status_code)
-        self.assertEqual(403, OwnerView().dispatch(self.dummy_request,
-            organization_pk=self.nirvana.pk).status_code)
+        with self.assertRaises(PermissionDenied):
+            OwnerView().dispatch(self.dummy_request,
+                                 organization_pk=self.nirvana.pk)


### PR DESCRIPTION
Moved from `HttpResponseForbidden` to `PermissionDenied` in access Mixins, as discussed in #89.

Let me know if something needs changing.