### PR TITLE
Fix RemovedInDjango110Warning for urlpatterns

### DIFF
--- a/organizations/urls.py
+++ b/organizations/urls.py
@@ -32,7 +32,7 @@ from .views import (OrganizationList, OrganizationDetail,
         OrganizationUserCreate, OrganizationUserRemind, OrganizationUserDelete)
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     # Organization URLs
     url(r'^$', view=login_required(OrganizationList.as_view()),
         name="organization_list"),
@@ -67,4 +67,4 @@ urlpatterns = patterns('',
     url(r'^(?P<organization_pk>[\d]+)/people/(?P<user_pk>[\d]+)/delete/$',
         view=login_required(OrganizationUserDelete.as_view()),
         name="organization_user_delete"),
-)
+]


### PR DESCRIPTION
Currently receiving `RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.` when running under Django 1.9.

This fixes that.