### PR TITLE
Adds search & filter fields to OrganizationAdmin class

### DIFF
--- a/organizations/admin.py
+++ b/organizations/admin.py
@@ -37,6 +37,8 @@ class OrganizationAdmin(admin.ModelAdmin):
     inlines = [OwnerInline]
     list_display = ['name', 'is_active']
     prepopulated_fields = {"slug": ("name",)}
+    search_fields = ['name']
+    list_filter = ('is_active',)
 
 
 class OrganizationUserAdmin(admin.ModelAdmin):


### PR DESCRIPTION
Addresses #106

This change allows users of the admin interface to search
organization’s by their name or filter out organizations based on their
active status.