### PR TITLE
Adding clean function to UserRegistrationForm to check password_confirm field

### DIFF
--- a/organizations/backends/forms.py
+++ b/organizations/backends/forms.py
@@ -25,6 +25,7 @@
 
 from django import forms
 from django.contrib.auth import get_user_model
+from django.utils.translation import ugettext_lazy as _
 
 from ..models import Organization
 
@@ -51,7 +52,7 @@ class UserRegistrationForm(forms.ModelForm):
         password = self.cleaned_data.get("password")
         password_confirm = self.cleaned_data.get("password_confirm")
         if password != password_confirm or not password:
-            raise forms.ValidationError("Your password entries must match")
+            raise forms.ValidationError(_("Your password entries must match"))
         return super(UserRegistrationForm, self).clean()
 
     class Meta:

--- a/organizations/backends/forms.py
+++ b/organizations/backends/forms.py
@@ -47,6 +47,13 @@ class UserRegistrationForm(forms.ModelForm):
         super(UserRegistrationForm, self).__init__(*args, **kwargs)
         self.initial['username'] = ''
 
+    def clean(self):
+        password = self.cleaned_data.get("password")
+        password_confirm = self.cleaned_data.get("password_confirm")
+        if password != password_confirm or not password:
+            raise forms.ValidationError("Your password entries must match")
+        return super(UserRegistrationForm, self).clean()
+
     class Meta:
         model = get_user_model()
         exclude = ('is_staff', 'is_superuser', 'is_active', 'last_login',


### PR DESCRIPTION
The UserRegistrationForm used by both the included RegistrationBackend
and InvitationBackend contains a password_confirm field, but does not
actually verify that the password and password_confirm fields match
before accepting the form submission as valid.

This commit addresses this problem by verifying the password and
confirm_password fields are equal via a `clean` function on this
form.

See the related issue https://github.com/bennylope/django-organizations/issues/92.