### PR TITLE
Build with correct Python versions in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,9 @@ python:
   - pypy
   - pypy3
 env:
-  - TOX_ENV=py34-django19
-  - TOX_ENV=py34-django18
-  - TOX_ENV=py27-django19
-  - TOX_ENV=py27-django18
-  - TOX_ENV=pypy-django19
-  - TOX_ENV=pypy-django18
+  - TOX_ENV=django10
+  - TOX_ENV=django19
+  - TOX_ENV=django18
   - TOX_ENV=flake8
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: python
-python: 2.7
+python: 
+  - 2.7
+  - 3.4
+  - 3.5
+  - pypy
+  - pypy3
 env:
   - TOX_ENV=py34-django19
   - TOX_ENV=py34-django18

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - 3.4
   - 3.5
   - pypy
-  - pypy3
 env:
   - TOX_ENV=django10
   - TOX_ENV=django19

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,6 +14,7 @@ Contributors:
 * `Tom Davis <https://github.com/tdavis>`_
 * `Nicolas Noirbent <https://github.com/noirbee>`_
 * `Samuel Bishop <https://github.com/techdragon>`_
+* `Jon Miller <https://github.com/jondelmil>`_
 
 If your name is missing as a contributor that's my oversight, let me know at
 ben@benlopatin.com

--- a/README.rst
+++ b/README.rst
@@ -171,10 +171,11 @@ requests/suggestions.
 Targets & testing
 -----------------
 
-The codebase is targeted at tested against:
+The codebase is targeted and tested against:
 
-* Django 1.8.x against Python 2.7, 3.4, 3.5
-* Django 1.9.x against Python 2.7, 3.4, 3.5
+* Django 1.8.x against Python 2.7, 3.4, 3.5, and PyPy
+* Django 1.9.x against Python 2.7, 3.4, 3.5, and PyPy
+* Django 1.10.x against Python 2.7, 3.4, 3.5, and PyPy
 
 To run the tests against all target environments, install `tox
 <https://testrun.org/tox/latest/>`_ and then execute the command:

--- a/organizations/base.py
+++ b/organizations/base.py
@@ -46,7 +46,7 @@ class UnicodeMixin(object):
         if six.PY3:
             return self.__unicode__()
         else:
-            return unicode(self).encode('utf-8')
+            return unicode(self).encode('utf-8')                # noqa
 
 
 class OrgMeta(ModelBase):

--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,6 @@ envlist =
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/organizations
 commands = py.test
-basepython =
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
-    pypy: pypy
-    pypy3: pypy3
-    jython: jython
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     flake8,
-    py{27,34,35}-django{18,19,10}
+    django{18,19,10}
 
 [testenv]
 setenv =


### PR DESCRIPTION
Looking through previous Travis CI builds, the Python used during testing is actually Python 2.7 every time, instead of py27, py34, py35 and pypy as expected.

This pull request removes different Python versions from tox.ini for local testing, but I think this is more appropriate since one usually only has a single Python version in a virtualenv for a given project. 

It moves the different python versions to be tested to .travis.yml's [`python`](https://docs.travis-ci.com/user/languages/python/#Choosing-Python-versions-to-test-against) section instead. If there's a better way to do all of this, let me know!