### PR TITLE
Send an email to existing, active Users that are added to an Organization

### DIFF
--- a/organizations/backends/defaults.py
+++ b/organizations/backends/defaults.py
@@ -244,6 +244,8 @@ class InvitationBackend(BaseBackend):
     A backend for inviting new users to join the site as members of an
     organization.
     """
+    notification_subject = 'organizations/email/notification_subject.txt'
+    notification_body = 'organizations/email/notification_body.html'
     invitation_subject = 'organizations/email/invitation_subject.txt'
     invitation_body = 'organizations/email/invitation_body.html'
     reminder_subject = 'organizations/email/reminder_subject.txt'
@@ -290,3 +292,18 @@ class InvitationBackend(BaseBackend):
         kwargs.update({'token': token})
         self._send_email(user, self.invitation_subject, self.invitation_body,
                 sender, **kwargs)
+
+    def send_notification(self, user, sender=None, **kwargs):
+        """
+        An intermediary function for sending an notification email informing
+        a pre-existing, active user that they have been added to a new
+        organization.
+        """
+        if not user.is_active:
+            return False
+        self._send_email(
+            user,
+            self.notification_subject,
+            self.notification_body,
+            sender,
+            **kwargs)

--- a/organizations/forms.py
+++ b/organizations/forms.py
@@ -97,6 +97,13 @@ class OrganizationUserAddForm(forms.ModelForm):
         """
         try:
             user = get_user_model().objects.get(email__iexact=self.cleaned_data['email'])
+            # Send a notification email to this user to inform them that they
+            # have been added to a new organization.
+            invitation_backend().send_notification(
+                user,
+                **{'domain': get_current_site(self.request),
+                    'organization': self.organization,
+                    'sender': self.request.user})
         except get_user_model().MultipleObjectsReturned:
             raise forms.ValidationError(_("This email address has been used multiple times."))
         except get_user_model().DoesNotExist:

--- a/organizations/templates/organizations/email/notification_body.html
+++ b/organizations/templates/organizations/email/notification_body.html
@@ -1,0 +1,7 @@
+You've been added to the organization {{ organization|safe }} on {{ domain.name }} by {{ sender.first_name|safe }} {{ sender.last_name|safe }}.
+
+Follow the link below to view this organization.
+
+http://{{ domain.domain }}{% url "organization_detail" organization.pk %}
+
+If you are unsure about this link please contact the sender.

--- a/organizations/templates/organizations/email/notification_subject.txt
+++ b/organizations/templates/organizations/email/notification_subject.txt
@@ -1,0 +1,1 @@
+{% spaceless %}You've been added to an organization{% endspaceless %}

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -75,6 +75,38 @@ class InvitationTests(TestCase):
             self.pending_user.id,
             self.tokenizer.make_token(self.pending_user)).status_code)
 
+    def test_send_notification_inactive_user(self):
+        """
+        This test verifies that calling the send_notification function
+        from the OrganizationsCoreInvitationBackend with an inactive Django
+        user causes the function to return False without sending an email.
+        """
+        org = Organization.objects.create(name="Test Organization")
+        result = InvitationBackend().send_notification(
+            self.pending_user,
+            domain='example.com',
+            organization=org,
+            sender=self.user)
+        self.assertEqual(result, False)
+        self.assertEquals(0, len(mail.outbox))
+
+    def test_send_notification_active_user(self):
+        """
+        This test verifies that calling the send_notification function
+        from the OrganizationsCoreInvitationBackend with an active Django
+        user causes the function send an email to that user.
+        """
+        org = Organization.objects.create(name="Test Organization")
+        InvitationBackend().send_notification(
+            self.user,
+            domain='example.com',
+            organization=org,
+            sender=self.pending_user)
+        self.assertEquals(1, len(mail.outbox))
+        self.assertEquals(
+            mail.outbox[0].subject,
+            u"You've been added to an organization")
+
 
 @override_settings(USE_TZ=True)
 class RegistrationTests(TestCase):


### PR DESCRIPTION
Currently, pre-existing and active users (i.e. Users _not_ created via an invitation to an organization) receive no notification that they have been added to an organization. This PR adds the send_notification function to the InvitationBackend to send an email informing these users that they have been added to an organization and providing them with a link they can follow to view this organization.

This PR implements #114.