### PR TITLE
adding django-extensions as dependency

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -49,6 +49,10 @@ settings file.::
         'organizations',
     )
 
+Run the migrations.::
+
+    python manage.py migrate
+
 This should work for the majority of cases, from either simple, out-of-the-box
 installations to custom organization models.
 

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     ],
     install_requires=[
         'Django>=1.8.0',
+        'django-extensions>=1.7.7',
     ],
     test_suite='tests',
     include_package_data=True,


### PR DESCRIPTION
Was just trying out your library, and after following the "getting started" docs, I got this error:

`Unhandled exception in thread started by <function check_errors.<locals>.wrapper at 0x107afd6a8>
Traceback (most recent call last):
  File "/redacted/python3.5/site-packages/organizations/fields.py", line 78, in <module>
    BaseSlugField = getattr(import_module(module), klass)
  File "/redacted/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 944, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 944, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 956, in _find_and_load_unlocked
ImportError: No module named 'django_extensions'

During handling of the above exception, another exception occurred:`