### PR TITLE
Fix documentation wrt *_BACKEND settings.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,7 +126,7 @@ You can specify a different invitation backend in your project settings, and
 the `invitation_backend` function will provide the URLs defined by that
 backend::
 
-    ORGS_INVITATION_BACKEND = 'myapp.backends.MyInvitationBackend'
+    INVITATION_BACKEND = 'myapp.backends.MyInvitationBackend'
 
 
 Usage Overview

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -79,8 +79,8 @@ your project settings, and the `invitation_backend` function will provide the
 URLs defined by that backend. You can do the same with the
 :ref:`registration backend <registration-backend>`::
 
-    ORGS_INVITATION_BACKEND = 'myapp.backends.MyInvitationBackend'
-    ORGS_REGISTRATION_BACKEND = 'myapp.backends.MyRegistrationBackend'
+    INVITATION_BACKEND = 'myapp.backends.MyInvitationBackend'
+    REGISTRATION_BACKEND = 'myapp.backends.MyRegistrationBackend'
 
 Auto slug field
 ---------------


### PR DESCRIPTION
I noticed the documentation was lying about the naming of INVITATION_BACKEND and REGISTRATION_BACKEND. This fixes that.

Alternatively, those settings should be renamed to match the docs. Please let me know if that is the case.