### PR TITLE
Document current supported Python/Django versions

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,6 +19,7 @@ Contributors:
 * `Robert Christopher <https://github.com/RobertChristopher>`_
 * `Basil Shubin <https://github.com/bashu>`_
 * `Federico Capoano <https://github.com/nemesisdesign>`_
+* `Justin Mayer <https://github.com/justinmayer>`_
 
 If your name is missing as a contributor that's my oversight, let me know at
 ben@benlopatin.com

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -116,13 +116,13 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst. Any new functionality should align with
    the project goals (see README).
-3. The pull request should work for Python 2.6, 2.7, and 3.3, and for PyPy. Check
-   https://travis-ci.org/bennylope/django-organizations/pull_requests
+3. The pull request should work on all Python & Django versions listed in `README
+   <https://github.com/bennylope/django-organizations/blob/dev/README.rst#targets--testing>`_.
+   Check https://travis-ci.org/bennylope/django-organizations/pull_requests
    and make sure that the tests pass for all supported Python versions.
-4. The pull request must also work with Django 1.4-1.7.
-5. Please try to follow `Django coding style
-   <https://docs.djangoproject.com/en/1.7/internals/contributing/writing-code/coding-style/>`_.
-6. Pull requests should include an amount of code and commits that are
+4. Please try to follow `Django coding style
+   <https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/coding-style/>`_.
+5. Pull requests should include an amount of code and commits that are
    reasonable to review, are **logically grouped**, and based off clean feature
    branches. Commits should be identifiable to the original author by
    name/username and email.

--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,8 @@ The codebase is targeted and tested against:
 
 * Django 1.8.x against Python 2.7, 3.4, 3.5, and PyPy
 * Django 1.9.x against Python 2.7, 3.4, 3.5, and PyPy
-* Django 1.10.x against Python 2.7, 3.4, 3.5, and PyPy
+* Django 1.10.x against Python 2.7, 3.4, 3.5, 3.6, and PyPy
+* Django 1.11.x against Python 2.7, 3.4, 3.5, 3.6, and PyPy
 
 To run the tests against all target environments, install `tox
 <https://testrun.org/tox/latest/>`_ and then execute the command::
@@ -232,7 +233,7 @@ reviewed and make it into the project:
 
 * Ensure they match the project goals and are sufficiently generalized
 * Please try to follow `Django coding style
-  <https://docs.djangoproject.com/en/1.8/internals/contributing/writing-code/coding-style/>`_.
+  <https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/coding-style/>`_.
   The code base style isn't all up to par, but I'd like it to move in that
   direction
 * Also please try to include `good commit log messages

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Framework :: Django',


### PR DESCRIPTION
Python 3.6 and Django 1.11 support was added in Django Organizations
v0.9.0, so this updates the README and setup.py to reflect that.

In an effort to reduce the number of places where we need to monitor and
update supported versions, the CONTRIBUTING document now refers to the
README as the canonical source of supported version information.

Lastly, links to the Django Coding Style document have been updated to
refer to the current stable version, instead of the hard-coded (and
outdated) versions to which they pointed previously.