### PR TITLE
Fix code errors in Cookbook > Proxy Models docs

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -22,7 +22,8 @@ delete account organizations, as well as users for those accounts.
 Proxy models for convenience
 ----------------------------
 
-This can be accomplished with proxy models in your models module.::
+This can be accomplished with proxy models in your models module (e.g.,
+``models.py``)::
 
     from organizations.models import Organization, OrganizationUser
 
@@ -58,16 +59,16 @@ account user form.
 Model admin definitions
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+In the admin module (e.g., ``admin.py``)::
 
     from django.contrib import admin
     from organizations.models import (Organization, OrganizationUser,
         OrganizationOwner)
-    from myapp.forms import UserAdminForm
+    from myapp.forms import AccountUserForm
     from myapp.models import Account, AccountUser
 
     class AccountUserAdmin(admin.ModelAdmin):
-        form = UserAdminForm()
+        form = AccountUserForm
 
     admin.site.unregister(Organization)
     admin.site.unregister(OrganizationUser)
@@ -79,16 +80,18 @@ It's very simple. All it does is ensure that the default Organization model
 interfaces are hidden and then substitute the form class on the AccountUser
 admin.
 
-That form is where the business all happens
+That form is where the business all happens.
 
 The admin form class
 ~~~~~~~~~~~~~~~~~~~~
 
-We'll go through this piece by piece, but here's the full class::
+We'll go through this piece by piece, but here's the full class (e.g., in
+``forms.py``)::
 
     from django import forms
     from django.conf import settings
     from django.contrib.sites.models import Site
+    from organizations.backends import invitation_backend
     from myapp.models import AccountUser
 
     class AccountUserForm(forms.ModelForm):


### PR DESCRIPTION
I ran into several errors when following the Cookbook > Proxy Models docs. The doc changes in this pull request are what I used to resolve those errors.

For the admin module, I feel fairly confident that the previous `form = UserAdminForm()` reference was intended to **(1)** instead refer to the `AccountUserForm` class in the `forms.py` code below, and **(2)** actually be a class instead of a function, but that was just my own intuition. Please feel free to correct me if those assumptions are mistaken.

This pull request also clarifies more explicitly which modules the suggested code is meant
to live in (e.g., `models.py`, `admin.py`, `forms.py`, respectively). With a bit of thinking I was able to infer from the headings which files were intended, but I think less-experienced Django developers (and I include myself in that category) will find the explicit filename suggestions to be helpful.