### PR TITLE
Configure Travis for supported Python+Django version matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
-language: python
-python: 2.7
-env:
-  - TOX_ENV=py34-django11
-  - TOX_ENV=py34-django18
-  - TOX_ENV=py27-django11
-  - TOX_ENV=py27-django18
-  - TOX_ENV=pypy-django11
-  - TOX_ENV=pypy-django18
-  - TOX_ENV=flake8
-install:
-  - pip install tox
-script:
-  - tox -e $TOX_ENV
 sudo: false
+
+# Following configures which base images are available to run tests
+dist: trusty
+language: python
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "pypy"
+
+install:
+  - pip install tox-travis
+script:
+  - tox
+
+matrix:
+  include:
+    - python: "2.7"
+      env: TOXENV=flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
     flake8,
-    py{27,34,35}-django{18,19,10,11}
-    py{36}-django{10,11}
+    py{27,34,35}-django{18,19,110,111},
+    py{36}-django{110,111},
+    pypy-django{18,19,110,111}
 
 [testenv]
 setenv =
@@ -19,8 +20,8 @@ basepython =
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
-    django10: Django>=1.10,<1.11
-    django11: Django>=1.11,<2
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2
     -r{toxinidir}/requirements-test.txt
 
 [testenv:flake8]


### PR DESCRIPTION
This configures Travis to test on the supported version matrix listed in
the project README. Refs #134