### PR TITLE
Create user's username only if model field exists

### DIFF
--- a/organizations/backends/defaults.py
+++ b/organizations/backends/defaults.py
@@ -27,6 +27,7 @@
 """
 
 import email.utils
+import inspect
 import uuid
 
 from django.conf import settings
@@ -274,8 +275,12 @@ class InvitationBackend(BaseBackend):
             user = self.user_model.objects.get(email=email)
         except self.user_model.DoesNotExist:
             # TODO break out user creation process
-            user = self.user_model.objects.create(username=self.get_username(),
-                    email=email, password=self.user_model.objects.make_random_password())
+            if 'username' in inspect.getargspec(self.user_model.objects.create_user).args:
+                user = self.user_model.objects.create(username=self.get_username(),
+                        email=email, password=self.user_model.objects.make_random_password())
+            else:
+                user = self.user_model.objects.create(email=email,
+                        password=self.user_model.objects.make_random_password())
             user.is_active = False
             user.save()
         self.send_invitation(user, sender, **kwargs)


### PR DESCRIPTION
The `invite_by_email()` function's user creation process assumed the
user model would have a `username` field, yielding an error for any
custom user model that does not have such a field (including, for
example, user models that use an email address as the username).

By inspecting the user model's `create_user()` function arguments, we can
avoid the aforementioned error by dropping the `username` argument when
no such field exists.