### PR TITLE
Remove requirement for first_name/last_name

### DIFF
--- a/organizations/backends/defaults.py
+++ b/organizations/backends/defaults.py
@@ -150,9 +150,9 @@ class BaseBackend(object):
                 display_name = sender.get_full_name()
             else:
                 display_name = sender.get_username()
-            from_email = "%s %s <%s>" % (display_name,
+            from_email = "%s <%s>" % (display_name,
                     email.utils.parseaddr(settings.DEFAULT_FROM_EMAIL)[1])
-            reply_to = "%s %s <%s>" % (display_name, sender.email)
+            reply_to = "%s <%s>" % (display_name, sender.email)
         else:
             from_email = settings.DEFAULT_FROM_EMAIL
             reply_to = from_email

--- a/organizations/backends/defaults.py
+++ b/organizations/backends/defaults.py
@@ -145,10 +145,14 @@ class BaseBackend(object):
         For instance, to send an HTML message, use the EmailMultiAlternatives message_class
         and attach the additional conent.
         """
+        if hasattr(sender, 'get_full_name') and callable(sender.get_full_name):
+            display_name = sender.get_full_name()
+        else:
+            display_name = sender.get_username()
         if sender:
-            from_email = "%s %s <%s>" % (sender.first_name, sender.last_name,
+            from_email = "%s %s <%s>" % (display_name,
                     email.utils.parseaddr(settings.DEFAULT_FROM_EMAIL)[1])
-            reply_to = "%s %s <%s>" % (sender.first_name, sender.last_name, sender.email)
+            reply_to = "%s %s <%s>" % (display_name, sender.email)
         else:
             from_email = settings.DEFAULT_FROM_EMAIL
             reply_to = from_email

--- a/organizations/backends/defaults.py
+++ b/organizations/backends/defaults.py
@@ -145,11 +145,11 @@ class BaseBackend(object):
         For instance, to send an HTML message, use the EmailMultiAlternatives message_class
         and attach the additional conent.
         """
-        if hasattr(sender, 'get_full_name') and callable(sender.get_full_name):
-            display_name = sender.get_full_name()
-        else:
-            display_name = sender.get_username()
         if sender:
+            if hasattr(sender, 'get_full_name') and callable(sender.get_full_name):
+                display_name = sender.get_full_name()
+            else:
+                display_name = sender.get_username()
             from_email = "%s %s <%s>" % (display_name,
                     email.utils.parseaddr(settings.DEFAULT_FROM_EMAIL)[1])
             reply_to = "%s %s <%s>" % (display_name, sender.email)


### PR DESCRIPTION
Hi,

I'm trying to implement this project and had a conflict between this and django-improved-user, which doesn't have first name or last name on users.

This recommendation guesses a display name based on the "get_full_name" method, which is recommended by Django (but is no longer required in Django 2.0) or falls back to the user name field.

Happy for feedback.