### PR TITLE
Add the `views` module to the Python package build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'organizations.backends',
         'organizations.migrations',
         'organizations.templatetags',
+        'organizations.views',
     ],
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
Look like when separating the views into a submodule, it wasn't added to the `setup.py` file. So all pre-release versions on PyPI are lacking the `organizations.views.*`.