### PR TITLE
Adding admin to installed apps in settings used for py.test.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -21,6 +21,7 @@ def pytest_configure():
             "django.contrib.auth",
             "django.contrib.contenttypes",
             "django.contrib.sites",
+            "django.contrib.admin",
             # The ordering here, the apps using the organization base models
             # first and *then* the organizations app itself is an implicit test
             # that the organizations app need not be installed in order to use


### PR DESCRIPTION
Previously, a ton of tests would fail because this was missing.