### PR TITLE
docs: Fix simple typo, inheritence -> inheritance

### DIFF
--- a/docs/custom_usage.rst
+++ b/docs/custom_usage.rst
@@ -135,9 +135,9 @@ verbosity::
 
 While this isn't recommended in your own project, the mixins in
 django-organizations itself will err on the side of depending on composition
-rather than inheritence from other mixins. This may require defining a mixin in
+rather than inheritance from other mixins. This may require defining a mixin in
 your own project that combines them for simplicity in your own views, but it
-reduces the inheritence chain potentially making functionality more difficult
+reduces the inheritance chain potentially making functionality more difficult
 ot identify.
 
 .. note::

--- a/organizations/abstract.py
+++ b/organizations/abstract.py
@@ -269,7 +269,7 @@ class AbstractOrganizationOwner(
         Method validates against the primary key of the organization because
         when validating an inherited model it may be checking an instance of
         `Organization` against an instance of `CustomOrganization`. Mutli-table
-        inheritence means the database keys will be identical though.
+        inheritance means the database keys will be identical though.
 
         """
         from organizations.exceptions import OrganizationMismatch

--- a/organizations/base.py
+++ b/organizations/base.py
@@ -57,7 +57,7 @@ class OrgMeta(ModelBase):
     Base metaclass for dynamically linking related organization models.
 
     This is particularly useful for custom organizations that can avoid
-    multitable inheritence and also add additional attributes to the
+    multitable inheritance and also add additional attributes to the
     organization users especially.
 
     The `module_registry` dictionary is used to track the architecture across


### PR DESCRIPTION
There is a small typo in docs/custom_usage.rst, organizations/abstract.py, organizations/base.py.

Should read `inheritance` rather than `inheritence`.

