### PR TITLE
Updated soon-deprecated django.utils.translation.ugettext_lazy() to django.utils.translation.gettext_lazy()

### DIFF
--- a/organizations/abstract.py
+++ b/organizations/abstract.py
@@ -27,7 +27,7 @@ import warnings
 
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from organizations.base import AbstractBaseOrganization
 from organizations.base import AbstractBaseOrganizationOwner

--- a/organizations/backends/defaults.py
+++ b/organizations/backends/defaults.py
@@ -48,7 +48,7 @@ from django.http import Http404
 from django.shortcuts import redirect
 from django.shortcuts import render
 from django.template import loader
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from organizations.backends.forms import UserRegistrationForm
 from organizations.backends.forms import org_registration_form

--- a/organizations/backends/forms.py
+++ b/organizations/backends/forms.py
@@ -25,7 +25,7 @@
 
 from django import forms
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class UserRegistrationForm(forms.ModelForm):

--- a/organizations/backends/modeled.py
+++ b/organizations/backends/modeled.py
@@ -43,7 +43,7 @@ from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect
 from django.shortcuts import render
 from django.template import loader
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from organizations.backends.defaults import InvitationBackend
 from organizations.backends.forms import UserRegistrationForm

--- a/organizations/base.py
+++ b/organizations/base.py
@@ -29,7 +29,7 @@ from django.conf import settings
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.models.base import ModelBase
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from organizations import signals
 from organizations.compat import reverse

--- a/organizations/forms.py
+++ b/organizations/forms.py
@@ -26,7 +26,7 @@
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.sites.shortcuts import get_current_site
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from organizations.backends import invitation_backend
 from organizations.models import Organization

--- a/organizations/views/base.py
+++ b/organizations/views/base.py
@@ -28,7 +28,7 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.http import HttpResponseBadRequest
 from django.shortcuts import redirect
 from django.shortcuts import render
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.generic import CreateView
 from django.views.generic import DeleteView
 from django.views.generic import DetailView

--- a/organizations/views/mixins.py
+++ b/organizations/views/mixins.py
@@ -26,7 +26,7 @@
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from organizations.models import Organization
 from organizations.models import OrganizationUser


### PR DESCRIPTION
The use of django.utils.translation.ugettext_lazy is causing a RemovedInDjango40Warning. Django 3 prefers gettext_lazy over ugettext_lazy, and this import will deprecated in a future version