### PR TITLE
🐛 Fix: Set default_auto_field to 'AutoField'

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 =======
 
+Unreleased
+----------
+
+* Better compatibility with Django 3.2
+
 2.0.0
 -----
 
@@ -61,8 +66,8 @@ At this point it seems reasonable to bump to version 1.
 * Add notification to users when added to an organization
 * New abstract models create separation between 'plain' base models and abstract
   models that include abstracted functionality previously included only in
-  concrete models 
-* Python 3.6 and Django 1.11 test support 
+  concrete models
+* Python 3.6 and Django 1.11 test support
 
 0.8.2
 -----

--- a/src/organizations/apps.py
+++ b/src/organizations/apps.py
@@ -6,3 +6,4 @@ from django.apps import AppConfig
 class OrganizationsConfig(AppConfig):
     name = "organizations"
     verbose_name = "Organizations"
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
This will avoid warnings in Django 3.2 and will avoid the creation of new migrations.

closed https://github.com/bennylope/django-organizations/issues/223