### PR TITLE
🔥 REMOVE the default_app_config definition

### DIFF
--- a/src/organizations/__init__.py
+++ b/src/organizations/__init__.py
@@ -4,6 +4,3 @@
 __author__ = "Ben Lopatin"
 __email__ = "ben@benlopatin.com"
 __version__ = "2.0.1"
-
-
-default_app_config = "organizations.apps.OrganizationsConfig"


### PR DESCRIPTION
Removing this is because to overcome the RemovedInDjango41Warning

Although I can suppress the warnings, but would be better if I can resolve it more permanently at the source

![image](https://user-images.githubusercontent.com/245021/157072417-3591dac9-8bd4-40aa-923c-4d0174c94a9e.png)

Please help to review @bennylope 