### PR TITLE
docs: Fix a few typos

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,7 +10,7 @@ Feature Scope section will be of particular interest to those looking to expand
 on this app's functionality, and the Pull Request Guidelines explain how I add
 code contributions.
 
-**Bug fix pull requests should be made agains the MASTER branch.**
+**Bug fix pull requests should be made against the MASTER branch.**
 
 Types of Contributions
 ======================
@@ -111,7 +111,7 @@ adding that in directly.
 Pull Request Guidelines
 =======================
 
-**Bug fix pull requests should be made agains the MASTER branch.**
+**Bug fix pull requests should be made against the MASTER branch.**
 
 Before you submit a pull request, check that it meets these guidelines:
 
@@ -136,7 +136,7 @@ versions of the software. You should be able to upgrade an installed version of
 Django Organizations by doing nothing more than upgrading the package and
 running `migrate`.
 
-**Bug fix pull requests should be made agains the MASTER branch.**
+**Bug fix pull requests should be made against the MASTER branch.**
 
 I am aiming to support each major Django version for `as long as it is
 supported

--- a/README.rst
+++ b/README.rst
@@ -209,7 +209,7 @@ Alternative:
     ORGS_SLUGFIELD = 'autoslug.fields.AutoSlugField'
 
 Previous versions allowed you to specify an `ORGS_TIMESTAMPED_MODEL` path. This
-is now ignored and the functionality satisifed by a vendored solution. A
+is now ignored and the functionality satisfied by a vendored solution. A
 warning will be given but this *should not* have any effect on your code.
 
 - `django-extensions <http://django-extensions.readthedocs.org/en/latest/>`_

--- a/docs/custom_usage.rst
+++ b/docs/custom_usage.rst
@@ -61,7 +61,7 @@ or::
     extended backend, if you are not already.
 
 This is worth noting here because Django Organizations is compatible with
-different user models in Django 1.4, which preceds the official swappable users
+different user models in Django 1.4, which precedes the official swappable users
 feature in Django 1.4.
 
 .. _mixins:

--- a/docs/reference/backends.rst
+++ b/docs/reference/backends.rst
@@ -9,7 +9,7 @@ users and creating new organizations**.
 While the default backends should suffice for basic implementations, the
 backends are designed to be easily extended for your specific project needs. If
 you make use of a profile model or a user model other than `auth.User` you
-should extend the releveant backends for your own project. If you've used
+should extend the relevant backends for your own project. If you've used
 custom URL names then you'll also want to extend the backends to use your own
 success URLs.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -59,7 +59,7 @@ or use the extensible invitation and registration backends.
 
 The default invitation backend accepts an email address and returns the user
 who either matches that email address or creates a new user with that email
-address. The view for adding a new user is then responsbile for adding this
+address. The view for adding a new user is then responsible for adding this
 user to the organization.
 
 The `OrganizationSignup` view is used for allowing a user new to the site to


### PR DESCRIPTION
There are small typos in:
- CONTRIBUTING.rst
- README.rst
- docs/custom_usage.rst
- docs/reference/backends.rst
- docs/usage.rst

Fixes:
- Should read `satisfied` rather than `satisifed`.
- Should read `responsible` rather than `responsbile`.
- Should read `relevant` rather than `releveant`.
- Should read `precedes` rather than `preceds`.
- Should read `against` rather than `agains`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md