### PR TITLE
Getting GH Actions tox testing working with currently supported Python versions and Django 2.2/3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.rst
+++ b/README.rst
@@ -88,9 +88,8 @@ Targets & testing
 
 The codebase is targeted and tested against:
 
-* Django 2.2.x against Python 3.5, 3.6, 3.7, 3.8
-* Django 3.0.x against Python 3.6, 3.7, 3.8
-* Django 3.1.x against Python 3.6, 3.7, 3.8
+* Django 2.2.x against Python 3.6, 3.7, 3.8
+* Django 3.2.x against Python 3.6, 3.7, 3.8, 3.9, 3.10
 
 To run the tests against all target environments, install `tox
 <https://testrun.org/tox/latest/>`_ and then execute the command::

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,22 @@
 [tox]
 envlist =
     flake8,
-    py{35,36,37,38}-django{22},
+    py{36,37,38}-django{22},
     py{36,37,38,39,310}-django{32},
-    py{37,38,39,310}-django{4},
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/organizations
 commands = pytest {posargs} --cov=organizations
 basepython =
-    py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8
@@ -24,7 +30,6 @@ deps =
     django3: Django>=3,<3.1
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<4
-    django4: Django==4.0a1
     -r{toxinidir}/requirements-test.txt
 
 [testenv:flake8]


### PR DESCRIPTION
Currently for Django 4 it appears there needs to be a migration added, which I'll handle in https://github.com/bennylope/django-organizations/pull/236 (still working on).  However this should get tests working for Django 2.2 (unsupported) and 3.2 (still in LTS) at least, and updates the README to reflect the versions that were already in the test matrix.