### PR TITLE
Adds 2.1.0 release information to HISTORY

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,6 +24,7 @@ Contributors:
 * `Samuel Spencer <https://github.com/LegoStormtroopr>`_
 * `Seb Vetter <https://github.com/elbaschid>`_
 * `KimSia Sim <https://github.com/simkimsia>`_
+* `Dan Moore <https://github.com/mgrdcm>`_
 
 If your name is missing as a contributor that's my oversight, let me know at
 ben@benlopatin.com

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,15 @@
 History
 =======
 
+2.1.0
+-----
+
+* Adds migrations to support Django 4.x
+* Removes support for Django < 3.2
+* Updates tox testing for supported configurations of Django 3.2 - 4.1 with Python 3.7 - 3.10
+* Early tox testing of Django 4.1 with Python 3.11
+* Fixes GitHub Actions automated testing
+
 2.0.2
 -----
 


### PR DESCRIPTION
Covers https://github.com/bennylope/django-organizations/pull/237 and the updates made in https://github.com/bennylope/django-organizations/pull/236.  And adds me as a contributing AUTHOR.