### PR TITLE
fix: include django-extensions as required installations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ package_dir=
 install_requires =
     six
     Django>=3.2.0
+    django-extensions>=2.0.8
 python_requires = >=3.8
 
 [options.packages.find]


### PR DESCRIPTION
Because autoslugfield requires django-extensions as indicated here https://github.com/bennylope/django-organizations/blob/2dd044956cf03dad9c8c4954ba325d2769fe3643/docs/getting_started.rst#auto-slug-field

and the minimum version is taken from https://github.com/bennylope/django-organizations/blob/2dd044956cf03dad9c8c4954ba325d2769fe3643/requirements-test.txt#L10