### PR TITLE
Make all default `send_*` funcs return result of `<message_class>.send()`

### DIFF
--- a/src/organizations/backends/defaults.py
+++ b/src/organizations/backends/defaults.py
@@ -128,7 +128,7 @@ class BaseBackend:
             return False
         token = PasswordResetTokenGenerator().make_token(user)
         kwargs.update({"token": token})
-        self.email_message(
+        return self.email_message(
             user, self.reminder_subject, self.reminder_body, sender, **kwargs
         ).send()
 
@@ -230,7 +230,7 @@ class RegistrationBackend(BaseBackend):
             return False
         token = self.get_token(user)
         kwargs.update({"token": token})
-        self.email_message(
+        return self.email_message(
             user, self.activation_subject, self.activation_body, sender, **kwargs
         ).send()
 
@@ -337,10 +337,9 @@ class InvitationBackend(BaseBackend):
             return False
         token = self.get_token(user)
         kwargs.update({"token": token})
-        self.email_message(
+        return self.email_message(
             user, self.invitation_subject, self.invitation_body, sender, **kwargs
         ).send()
-        return True
 
     def send_notification(self, user, sender=None, **kwargs):
         """
@@ -350,7 +349,6 @@ class InvitationBackend(BaseBackend):
         """
         if not user.is_active:
             return False
-        self.email_message(
+        return self.email_message(
             user, self.notification_subject, self.notification_body, sender, **kwargs
         ).send()
-        return True


### PR DESCRIPTION
Right now 2 implicitly return this already, and 2 explicitly only return `True` if it gets that far.

This is technically a breaking change, though as far as I can tell the return values of those functions aren't documented right now so...

Note that the `modeled.ModelInvitation`'s version already does exactly this explicitly.

(note was originally gonna unify these like https://github.com/bennylope/django-organizations/pull/276 but this is just as half-backwards-compatible and also exposes more useful information)