### PR TITLE
Testing is actually against Django 5.2 not 5.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ The codebase is targeted and tested against:
 
 * Django 3.2.x against Python 3.8, 3.9, 3.10
 * Django 4.2.x against Python 3.8, 3.9, 3.10, 3.11, 3.12
-* Django 5.1.x against Python 3.10, 3.11, 3.12
+* Django 5.2.x against Python 3.10, 3.11, 3.12, 3.13
 
 To run the tests against all target environments, install `tox
 <https://testrun.org/tox/latest/>`_ and then execute the command::

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
     hatch>=1.7.0
     django32: Django>=3.2,<4
     django42: Django>=4.2,<5
-    django51: Django>=5.2,<6
+    django52: Django>=5.2,<6
 extras = tests
 
 [testenv:flake8]


### PR DESCRIPTION
I'd say should test again 5.1 too but it leaves extended support in a few days... https://www.djangoproject.com/download/#supported-versions