### PR TITLE
Allow passing context to rendered templates via `extra_context` param to view method.

### DIFF
--- a/docs/reference/backends.rst
+++ b/docs/reference/backends.rst
@@ -168,7 +168,7 @@ The primary methods of interest are the `invite_by_email` method and the
         
         domain={ "name": "My Site", "domain": "www.example.com" }
     
-.. method:: InvitationBackend.activate_view(request, user_id, token)
+.. method:: InvitationBackend.activate_view(request, user_id, token, extra_context=None)
 
   This method is a view for activating a user account via a unique link sent
   via email. The view ensures the token matches a user and is valid, that the

--- a/src/organizations/backends/defaults.py
+++ b/src/organizations/backends/defaults.py
@@ -106,7 +106,7 @@ class BaseBackend:
             org.is_active = True
             org.save()
 
-    def activate_view(self, request, user_id, token):
+    def activate_view(self, request, user_id, token, extra_context=None):
         """
         View function that activates the given User by setting `is_active` to
         true if the provided information is verified.
@@ -135,7 +135,7 @@ class BaseBackend:
                 raise Http404(_("Can't authenticate user"))
             login(request, user)
             return redirect(self.get_success_url())
-        return render(request, self.registration_form_template, {"form": form})
+        return render(request, self.registration_form_template, {"form": form, **(extra_context or {})})
 
     def send_reminder(self, user, sender=None, **kwargs):
         """Sends a reminder email to the specified user"""
@@ -249,7 +249,7 @@ class RegistrationBackend(BaseBackend):
             user, self.activation_subject, self.activation_body, sender, **kwargs
         ).send()
 
-    def create_view(self, request):
+    def create_view(self, request, extra_context=None):
         """
         Initiates the organization and user account creation process
         """
@@ -278,12 +278,12 @@ class RegistrationBackend(BaseBackend):
             return render(
                 request,
                 self.activation_success_template,
-                {"user": user, "organization": organization},
+                {"user": user, "organization": organization, **(extra_context or {})},
             )
-        return render(request, self.registration_form_template, {"form": form})
+        return render(request, self.registration_form_template, {"form": form, **(extra_context or {})})
 
-    def success_view(self, request):
-        return render(request, self.activation_success_template, {})
+    def success_view(self, request, extra_context=None):
+        return render(request, self.activation_success_template, {**(extra_context or {})})
 
 
 class InvitationBackend(BaseBackend):


### PR DESCRIPTION
This adds a way to pass additional context to the various forms that `django-organizations` renders via its `*_view` methods.  Followed pattern from Django for doing this.

Need this for integrating with another package (https://github.com/unfoldadmin/django-unfold) but useful in general to be able to get data into custom templates.