### PR TITLE
Add asyncio support with a-prefixed methods

### DIFF
--- a/src/organizations/abstract.py
+++ b/src/organizations/abstract.py
@@ -104,6 +104,23 @@ class AbstractOrganization(
         user_added.send(sender=self, user=user)
         return org_user
 
+    async def aadd_user(self, user, is_admin=False):
+        """Async version of ``add_user``."""
+        users_count = await self.users.acount()
+        if users_count == 0:
+            is_admin = True
+        org_user = await self._org_user_model.objects.acreate(
+            user=user, organization=self, is_admin=is_admin
+        )
+        if users_count == 0:
+            await self._org_owner_model.objects.acreate(
+                organization=self, organization_user=org_user
+            )
+
+        # User added signal
+        await user_added.asend(sender=self, user=user)
+        return org_user
+
     def remove_user(self, user):
         """
         Deletes a user from an organization.
@@ -113,6 +130,16 @@ class AbstractOrganization(
 
         # User removed signal
         user_removed.send(sender=self, user=user)
+
+    async def aremove_user(self, user):
+        """
+        Async version of ``remove_user``.
+        """
+        org_user = await self._org_user_model.objects.aget(user=user, organization=self)
+        await org_user.adelete()
+
+        # User removed signal
+        await user_removed.asend(sender=self, user=user)
 
     def get_or_add_user(self, user, **kwargs):
         """
@@ -143,6 +170,27 @@ class AbstractOrganization(
             user_added.send(sender=self, user=user)
         return org_user, created
 
+    async def aget_or_add_user(self, user, **kwargs):
+        """
+        Async version of ``get_or_add_user``.
+        """
+        is_admin = kwargs.pop("is_admin", False)
+        users_count = await self.users.acount()
+        if users_count == 0:
+            is_admin = True
+
+        org_user, created = await self._org_user_model.objects.aget_or_create(
+            organization=self, user=user, defaults={"is_admin": is_admin}
+        )
+        if users_count == 0:
+            await self._org_owner_model.objects.acreate(
+                organization=self, organization_user=org_user
+            )
+        if created:
+            # User added signal
+            await user_added.asend(sender=self, user=user)
+        return org_user, created
+
     def change_owner(self, new_owner):
         """
         Changes ownership of an organization.
@@ -154,6 +202,20 @@ class AbstractOrganization(
         # Owner changed signal
         owner_changed.send(sender=self, old=old_owner, new=new_owner)
 
+    async def achange_owner(self, new_owner):
+        """Async version of ``change_owner``."""
+        # Fetch the owner explicitly; the lazy ``self.owner`` accessor would
+        # raise SynchronousOnlyOperation here.
+        owner = await self._org_owner_model.objects.select_related(
+            "organization_user"
+        ).aget(organization=self)
+        old_owner = owner.organization_user
+        owner.organization_user = new_owner
+        await owner.asave()
+
+        # Owner changed signal
+        await owner_changed.asend(sender=self, old=old_owner, new=new_owner)
+
     def is_admin(self, user):
         """
         Returns True is user is an admin in the organization, otherwise false
@@ -162,11 +224,26 @@ class AbstractOrganization(
             True if self.organization_users.filter(user=user, is_admin=True) else False
         )
 
+    async def ais_admin(self, user):
+        """
+        Async version of ``is_admin``.
+        """
+        return await self.organization_users.filter(user=user, is_admin=True).aexists()
+
     def is_owner(self, user):
         """
         Returns True is user is the organization's owner, otherwise false
         """
         return self.owner.organization_user.user == user
+
+    async def ais_owner(self, user):
+        """
+        Async version of ``is_owner``.
+        """
+        owner = await self._org_owner_model.objects.select_related(
+            "organization_user"
+        ).aget(organization=self)
+        return owner.organization_user.user_id == user.pk
 
 
 class AbstractOrganizationUser(
@@ -189,7 +266,7 @@ class AbstractOrganizationUser(
             self.organization.name,
         )
 
-    def delete(self, using=None):
+    def delete(self, using=None, keep_parents=False):
         """
         If the organization user is also the owner, this should not be deleted
         unless it's part of a cascade from the Organization.
@@ -209,7 +286,9 @@ class AbstractOrganizationUser(
         # TODO This line presumes that OrgOwner model can't be modified
         except self._org_owner_model.DoesNotExist:
             pass
-        super().delete(using=using)
+        # ``keep_parents`` mirrors ``Model.delete``; ``Model.adelete`` forwards
+        # it, so the override must accept and pass it through.
+        super().delete(using=using, keep_parents=keep_parents)
 
     def get_absolute_url(self):
         return reverse(

--- a/src/organizations/base.py
+++ b/src/organizations/base.py
@@ -237,6 +237,12 @@ class AbstractBaseOrganization(models.Model):
     def is_member(self, user):
         return True if user in self.users.all() else False
 
+    async def ais_member(self, user):
+        """
+        Async version of ``is_member``.
+        """
+        return await self.users.filter(pk=user.pk).aexists()
+
 
 class OrganizationBase(with_metaclass(OrgMeta, AbstractBaseOrganization)):
     class Meta(AbstractBaseOrganization.Meta):
@@ -251,6 +257,16 @@ class OrganizationBase(with_metaclass(OrgMeta, AbstractBaseOrganization)):
             user=user, organization=self, **kwargs
         )
         signals.user_added.send(sender=self, user=user)
+        return org_user
+
+    async def aadd_user(self, user, **kwargs):
+        """
+        Async version of ``add_user``.
+        """
+        org_user = await self._org_user_model.objects.acreate(
+            user=user, organization=self, **kwargs
+        )
+        await signals.user_added.asend(sender=self, user=user)
         return org_user
 
 
@@ -364,6 +380,17 @@ class AbstractBaseInvitation(models.Model):
         org_user = self.organization.add_user(user, **self.activation_kwargs())
         self.invitee = user
         self.save()
+        return org_user
+
+    async def aactivate(self, user):
+        """Async version of ``activate``."""
+        # Load the organization explicitly; the lazy ``self.organization``
+        # accessor would raise SynchronousOnlyOperation here.
+        org_model = self._meta.get_field("organization").related_model
+        organization = await org_model.objects.aget(pk=self.organization_id)
+        org_user = await organization.aadd_user(user, **self.activation_kwargs())
+        self.invitee = user
+        await self.asave()
         return org_user
 
     def invitation_token(self):

--- a/src/organizations/utils.py
+++ b/src/organizations/utils.py
@@ -27,27 +27,15 @@ def model_field_names(model):
     )
 
 
-def create_organization(
-    user,
-    name,
-    slug=None,
-    is_active=None,
-    org_defaults=None,
-    org_user_defaults=None,
-    **kwargs,
+def _resolve_organization_models(
+    user, name, slug, is_active, org_defaults, org_user_defaults, kwargs
 ):
     """
-    Returns a new organization, also creating an initial organization user who
-    is the owner.
+    Resolves the models and default values shared by ``create_organization`` and
+    ``acreate_organization``.
 
-    The specific models can be specified if a custom organization app is used.
-    The simplest way would be to use a partial.
-
-    >>> from organizations.utils import create_organization
-    >>> from myapp.models import Account
-    >>> from functools import partial
-    >>> create_account = partial(create_organization, model=Account)
-
+    Returns a tuple of ``(org_model, org_user_model, org_owner_model,
+    org_defaults, org_user_defaults)`` ready to be passed to the (a)sync ORM.
     """
     org_model = (
         kwargs.pop("model", None)
@@ -73,12 +61,79 @@ def create_organization(
         org_defaults.update({"is_active": is_active})
 
     org_defaults.update({"name": name})
+    org_user_defaults.update({"user": user})
+    return org_model, org_user_model, org_owner_model, org_defaults, org_user_defaults
+
+
+def create_organization(
+    user,
+    name,
+    slug=None,
+    is_active=None,
+    org_defaults=None,
+    org_user_defaults=None,
+    **kwargs,
+):
+    """
+    Returns a new organization, also creating an initial organization user who
+    is the owner.
+
+    The specific models can be specified if a custom organization app is used.
+    The simplest way would be to use a partial.
+
+    >>> from organizations.utils import create_organization
+    >>> from myapp.models import Account
+    >>> from functools import partial
+    >>> create_account = partial(create_organization, model=Account)
+
+    """
+    (
+        org_model,
+        org_user_model,
+        org_owner_model,
+        org_defaults,
+        org_user_defaults,
+    ) = _resolve_organization_models(
+        user, name, slug, is_active, org_defaults, org_user_defaults, kwargs
+    )
+
     organization = org_model.objects.create(**org_defaults)
 
-    org_user_defaults.update({"organization": organization, "user": user})
+    org_user_defaults.update({"organization": organization})
     new_user = org_user_model.objects.create(**org_user_defaults)
 
     org_owner_model.objects.create(
+        organization=organization, organization_user=new_user
+    )
+    return organization
+
+
+async def acreate_organization(
+    user,
+    name,
+    slug=None,
+    is_active=None,
+    org_defaults=None,
+    org_user_defaults=None,
+    **kwargs,
+):
+    """Async version of ``create_organization``."""
+    (
+        org_model,
+        org_user_model,
+        org_owner_model,
+        org_defaults,
+        org_user_defaults,
+    ) = _resolve_organization_models(
+        user, name, slug, is_active, org_defaults, org_user_defaults, kwargs
+    )
+
+    organization = await org_model.objects.acreate(**org_defaults)
+
+    org_user_defaults.update({"organization": organization})
+    new_user = await org_user_model.objects.acreate(**org_user_defaults)
+
+    await org_owner_model.objects.acreate(
         organization=organization, organization_user=new_user
     )
     return organization

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,184 @@
+"""
+Tests for the asynchronous (``a``-prefixed) API.
+
+These mirror the synchronous model/util tests in ``test_models.py`` but exercise
+the real asyncio code paths (Django's async ORM and ``Signal.asend``).
+"""
+
+from unittest import skipUnless
+
+from django.contrib.auth.models import User
+from django.dispatch import Signal
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from organizations.models import Organization
+from organizations.models import OrganizationUser
+from organizations.signals import owner_changed
+from organizations.signals import user_added
+from organizations.signals import user_removed
+from organizations.utils import acreate_organization
+from test_accounts.models import Account
+from test_accounts.models import AccountInvitation
+
+# Async signal dispatch (``Signal.asend``) requires Django 5.0+. The async API
+# is not supported on the (end-of-life) Django 4.2 series.
+requires_async_signals = skipUnless(
+    hasattr(Signal, "asend"), "Async API requires Django 5.0+ (Signal.asend)"
+)
+
+
+@requires_async_signals
+@override_settings(USE_TZ=True)
+class AsyncOrgModelTests(TestCase):
+    fixtures = ["users.json", "orgs.json"]
+
+    def setUp(self):
+        self.kurt = User.objects.get(username="kurt")
+        self.dave = User.objects.get(username="dave")
+        self.krist = User.objects.get(username="krist")
+        self.duder = User.objects.get(username="duder")
+        self.nirvana = Organization.objects.get(name="Nirvana")
+        self.foo = Organization.objects.get(name="Foo Fighters")
+
+    async def test_ais_member(self):
+        self.assertTrue(await self.nirvana.ais_member(self.kurt))
+        self.assertTrue(await self.nirvana.ais_member(self.dave))
+        self.assertTrue(await self.foo.ais_member(self.dave))
+        self.assertFalse(await self.foo.ais_member(self.kurt))
+
+    async def test_ais_admin(self):
+        self.assertTrue(await self.nirvana.ais_admin(self.kurt))
+        self.assertTrue(await self.nirvana.ais_admin(self.krist))
+        self.assertFalse(await self.nirvana.ais_admin(self.dave))
+        self.assertTrue(await self.foo.ais_admin(self.dave))
+
+    async def test_ais_owner(self):
+        self.assertTrue(await self.nirvana.ais_owner(self.kurt))
+        self.assertTrue(await self.foo.ais_owner(self.dave))
+        self.assertFalse(await self.nirvana.ais_owner(self.dave))
+        self.assertFalse(await self.nirvana.ais_owner(self.krist))
+
+    async def test_aadd_user(self):
+        received = []
+
+        def receiver(sender, user, **kwargs):
+            received.append(user)
+
+        user_added.connect(receiver, weak=False)
+        try:
+            new_guy = await self.foo.aadd_user(self.krist)
+        finally:
+            user_added.disconnect(receiver)
+        self.assertTrue(isinstance(new_guy, OrganizationUser))
+        self.assertEqual(new_guy.organization_id, self.foo.pk)
+        self.assertEqual(received, [self.krist])
+
+    async def test_aadd_user_first_user_is_owner(self):
+        org = await Organization.objects.acreate(name="Empty", slug="empty")
+        org_user = await org.aadd_user(self.duder)
+        self.assertTrue(org_user.is_admin)
+        self.assertTrue(await org.ais_owner(self.duder))
+
+    async def test_aremove_user(self):
+        received = []
+
+        def receiver(sender, user, **kwargs):
+            received.append(user)
+
+        await self.foo.aadd_user(self.krist)
+        user_removed.connect(receiver, weak=False)
+        try:
+            await self.foo.aremove_user(self.krist)
+        finally:
+            user_removed.disconnect(receiver)
+        self.assertFalse(await self.foo.users.filter(pk=self.krist.pk).aexists())
+        self.assertEqual(received, [self.krist])
+
+    async def test_aget_or_add_user(self):
+        new_guy, created = await self.foo.aget_or_add_user(self.duder)
+        self.assertTrue(isinstance(new_guy, OrganizationUser))
+        self.assertEqual(new_guy.organization_id, self.foo.pk)
+        self.assertTrue(created)
+
+        existing, created = await self.foo.aget_or_add_user(self.dave)
+        self.assertTrue(isinstance(existing, OrganizationUser))
+        self.assertFalse(created)
+
+    async def test_achange_owner(self):
+        received = []
+
+        def receiver(sender, old, new, **kwargs):
+            received.append((old, new))
+
+        admin = await OrganizationUser.objects.aget(
+            organization=self.nirvana, user=self.krist
+        )
+        owner_changed.connect(receiver, weak=False)
+        try:
+            await self.nirvana.achange_owner(admin)
+        finally:
+            owner_changed.disconnect(receiver)
+        owner = await self.nirvana._org_owner_model.objects.aget(
+            organization=self.nirvana
+        )
+        self.assertEqual(owner.organization_user_id, admin.pk)
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0][1], admin)
+
+
+@requires_async_signals
+@override_settings(USE_TZ=True)
+class AsyncBaseOrganizationTests(TestCase):
+    """Exercise the async API on the lighter ``OrganizationBase`` line."""
+
+    fixtures = ["users.json"]
+
+    def setUp(self):
+        self.kurt = User.objects.get(username="kurt")
+        self.dave = User.objects.get(username="dave")
+
+    async def test_aadd_user(self):
+        account = await Account.objects.acreate(name="Acme")
+        received = []
+
+        def receiver(sender, user, **kwargs):
+            received.append(user)
+
+        user_added.connect(receiver, weak=False)
+        try:
+            org_user = await account.aadd_user(self.dave)
+        finally:
+            user_added.disconnect(receiver)
+        self.assertEqual(org_user.organization_id, account.pk)
+        self.assertTrue(await account.ais_member(self.dave))
+        self.assertEqual(received, [self.dave])
+
+    async def test_aactivate(self):
+        account = await Account.objects.acreate(name="InviteCo")
+        invitation = await AccountInvitation.objects.acreate(
+            invitee_identifier="newbie@example.com",
+            invited_by=self.kurt,
+            organization=account,
+        )
+        org_user = await invitation.aactivate(self.dave)
+        self.assertEqual(org_user.organization_id, account.pk)
+        self.assertTrue(await account.ais_member(self.dave))
+        refreshed = await AccountInvitation.objects.aget(pk=invitation.pk)
+        self.assertEqual(refreshed.invitee_id, self.dave.pk)
+
+
+@requires_async_signals
+@override_settings(USE_TZ=True)
+class AsyncCreateOrganizationTests(TestCase):
+    fixtures = ["users.json", "orgs.json"]
+
+    def setUp(self):
+        self.dave = User.objects.get(username="dave")
+
+    async def test_acreate_organization(self):
+        org = await acreate_organization(self.dave, "Async Org", slug="async-org")
+        self.assertTrue(await Organization.objects.filter(name="Async Org").aexists())
+        self.assertTrue(await org.ais_owner(self.dave))
+        owner_org_user = await OrganizationUser.objects.aget(organization=org)
+        self.assertTrue(owner_org_user.is_admin)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     flake8,
-    py{310}-django{32}
     py{310,311,312}-django{42}
     py{310,311,312,313,314}-django{52}
     py{312,313,314}-django{60}


### PR DESCRIPTION
Add django-style a-prefix async functions to core utilities. I did not extend this to views to keep it minimal. Claude was used to create this code and reviewed by me. I also tested it against my project, GlitchTip, units tests.

Email is a notable omission. It should be async but Django doesn't currently support this.

New async methods:
- `AbstractOrganization.aadd_user` / `aremove_user` / `aget_or_add_user` / `achange_owner` / `ais_admin` / `ais_owner`
- `AbstractBaseOrganization.ais_member`
- `OrganizationBase.aadd_user`
- `AbstractBaseInvitation.aactivate`
- `organizations.utils.acreate_organization`

Also:
- Fix `AbstractOrganizationUser.delete()` to accept `keep_parents`, which Django's `Model.adelete()` passes through (previously raised TypeError on async delete and any caller passing the argument).
- Factor the shared model/default resolution in `create_organization` into a helper reused by the async variant.
- Drop the stale `py310-django32` tox env; async ORM/signals require Django 4.1+ and the package already declares `Django>=4.2`.

If requested, I could make the views async too but I'm not sure if many users would care. I don't personally use the views. To get real asyncio ORM, one would have to use django-async-backend.