### PR TITLE
Add Django 6.1 testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,17 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        django-version: ["52", "60"]
+        django-version: ["52", "60", "61"]
         exclude:
-          # Django 6.0 requires Python 3.12+
+          # Django 6.0/6.1 requires Python 3.12+
           - python-version: "3.10"
             django-version: "60"
           - python-version: "3.11"
             django-version: "60"
+          - python-version: "3.10"
+            django-version: "61"
+          - python-version: "3.11"
+            django-version: "61"
 
     steps:
     - uses: actions/checkout@v4

--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,7 @@ The codebase is targeted and tested against:
 
 * Django 5.2.x against Python 3.10, 3.11, 3.12, 3.13, 3.14
 * Django 6.0.x against Python 3.12, 3.13, 3.14
+* Django 6.1.x against Python 3.12, 3.13, 3.14
 
 To run the tests against all target environments, install `tox
 <https://tox.wiki/>`_ and then execute the command::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
+    "Framework :: Django :: 6.1",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python",

--- a/tox.ini
+++ b/tox.ini
@@ -18,4 +18,5 @@ basepython =
 deps =
     django52: Django>=5.2.8,<6  # Django 5.2.8 is required for Python 3.14 support
     django60: Django>=6.0,<6.1
+    django61: Django>=6.1,<6.2
 dependency_groups = tests


### PR DESCRIPTION
Adds Django 6.1 testing and declarations.

~Should probably wait until after https://github.com/bennylope/django-organizations/pull/308 is merged so the lint step passes.~