### PR TITLE
Limit `ruff` to `<0.16` for now

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install ruff
-        run: pip install ruff
+        run: pip install "ruff<0.16"
       - name: Run ruff
         run: |
           ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ tests = [
 ]
 dev = [
     {include-group = "tests"},
-    "ruff",
+    "ruff<0.16",
     "tox",
     "pre-commit",
 ]


### PR DESCRIPTION
[Version 0.16](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#0160) "enables a much larger set of rules by default (413, up from 59). See the blog post for more details and the new Default Rules page for a full listing of the enabled rules."

So until we want to fix all of those violations, this will fix builds.